### PR TITLE
RDNS migration: apply HashiCorp's recommendations

### DIFF
--- a/linode/rdns/framework_resource.go
+++ b/linode/rdns/framework_resource.go
@@ -60,7 +60,7 @@ func (r *Resource) Create(
 
 	if ip.RDNS != defaultRdns {
 		resp.Diagnostics.AddWarning(
-			"Pre-exist RDNS configuration",
+			"Pre-modified RDNS Address",
 			"RDNS was already configured before the creation of this RDNS resource",
 		)
 	}


### PR DESCRIPTION
> A recommendation when implementing the Read method:
> 
> Ignore returning errors that signify the resource is no longer existent, call the response state RemoveResource() method, and return early. The next Terraform plan will recreate the resource.

https://developer.hashicorp.com/terraform/plugin/framework/resources/read#recommendations

> 
> A recommendation when implementing the Create method:
> 
> Return errors that signify there is an existing resource. Terraform practitioners expect to be notified if an existing resource needs to be imported into Terraform rather than created. This prevents situations where multiple Terraform configurations unexpectedly manage the same underlying resource.

https://developer.hashicorp.com/terraform/plugin/framework/resources/create#recommendations
Although the original recommendation was adding an error, this resource is not for creating any resource but editing the rdns field. So, I think it's okay to just have a warning instead of an error. But I am not very sure, so we can change it to be an error if you guys think that's more reasonable.
